### PR TITLE
Update upstream

### DIFF
--- a/Telegram/Patches/crashpad.diff
+++ b/Telegram/Patches/crashpad.diff
@@ -1,23 +1,3 @@
-diff --git a/build/crashpad.gypi b/build/crashpad.gypi
-index 027c7b68..4bfdfb5a 100644
---- a/build/crashpad.gypi
-+++ b/build/crashpad.gypi
-@@ -25,5 +25,15 @@
-       4201,  # nonstandard extension used : nameless struct/union.
-       4324,  # structure was padded due to __declspec(align()).
-     ],
-+    'xcode_settings': {
-+      'OTHER_CPLUSPLUSFLAGS': [ '-nostdinc++' ],
-+      'OTHER_LDFLAGS': [
-+        '/usr/local/macold/lib/libc++.a',
-+        '/usr/local/macold/lib/libc++abi.a',
-+      ],
-+    },
-+    'include_dirs': [
-+      '/usr/local/macold/include/c++/v1',
-+    ],
-   },
- }
 diff --git a/client/capture_context_mac_test.cc b/client/capture_context_mac_test.cc
 index 436ac5ad..8e14fb9c 100644
 --- a/client/capture_context_mac_test.cc

--- a/docs/building-xcode.md
+++ b/docs/building-xcode.md
@@ -102,6 +102,7 @@ Go to ***BuildPath*** and run
     git clone https://chromium.googlesource.com/crashpad/crashpad.git
     cd crashpad
     git checkout feb3aa3923
+    git apply ../../../tdesktop/Telegram/Patches/crashpad.diff
     cd third_party/mini_chromium
     git clone https://chromium.googlesource.com/chromium/mini_chromium
     cd mini_chromium


### PR DESCRIPTION
Some tests were disabled by a crashpad patch because the changes to make
them work with new SDK are relatively big and no need to backport them.

Fixes #4353.