### PR TITLE
Update upstream

### DIFF
--- a/Telegram/SourceFiles/chat_helpers/emoji_suggestions_widget.cpp
+++ b/Telegram/SourceFiles/chat_helpers/emoji_suggestions_widget.cpp
@@ -401,7 +401,7 @@ QString SuggestionsController::getEmojiQuery() {
 			}
 			position -= from;
 			_queryStartPosition = from;
-			return fragment.text().toLower();
+			return fragment.text();
 		}
 		return QString();
 	};
@@ -411,10 +411,18 @@ QString SuggestionsController::getEmojiQuery() {
 		return QString();
 	}
 
-	auto isSuggestionChar = [](QChar ch) {
-		return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || (ch == '_') || (ch == '-') || (ch == '+');
+	const auto isUpperCaseLetter = [](QChar ch) {
+		return (ch >= 'A' && ch <= 'Z');
 	};
-	auto isGoodCharBeforeSuggestion = [isSuggestionChar](QChar ch) {
+	const auto isSuggestionChar = [](QChar ch) {
+		return (ch >= 'a' && ch <= 'z')
+			|| (ch >= 'A' && ch <= 'Z')
+			|| (ch >= '0' && ch <= '9')
+			|| (ch == '_')
+			|| (ch == '-')
+			|| (ch == '+');
+	};
+	const auto isGoodCharBeforeSuggestion = [&](QChar ch) {
 		return !isSuggestionChar(ch) || (ch == 0);
 	};
 	Assert(position > 0 && position <= text.size());
@@ -427,7 +435,14 @@ QString SuggestionsController::getEmojiQuery() {
 				if (position > i + 1) {
 					// Skip colon and the first letter.
 					_queryStartPosition += i + 2;
-					return text.mid(i, position - i);
+					const auto length = position - i;
+					auto result = text.mid(i, length);
+					if (length == 2 && isUpperCaseLetter(text[1])) {
+						// No upper case single letter suggestions.
+						// We don't want to suggest emoji on :D and :P
+						return QString();
+					}
+					return result.toLower();
 				}
 			}
 			return QString();

--- a/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp
+++ b/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp
@@ -919,7 +919,7 @@ void StickersListWidget::refreshSearchRows(
 	_searchSets.clear();
 	fillLocalSearchRows(_searchNextQuery);
 
-	if (!cloudSets && _searchSets.empty()) {
+	if (!cloudSets && _searchNextQuery.isEmpty()) {
 		showStickerSet(!_mySets.empty()
 			? _mySets[0].id
 			: Stickers::FeaturedSetId);
@@ -1711,7 +1711,11 @@ void StickersListWidget::refreshSearchSets() {
 void StickersListWidget::refreshSearchIndex() {
 	_searchIndex.clear();
 	for (const auto &set : _mySets) {
-		const auto list = TextUtilities::PrepareSearchWords(set.title + ' ' + set.shortName);
+		if (set.flags & MTPDstickerSet_ClientFlag::f_special) {
+			continue;
+		}
+		const auto string = set.title + ' ' + set.shortName;
+		const auto list = TextUtilities::PrepareSearchWords(string);
 		_searchIndex.emplace_back(set.id, list);
 	}
 }

--- a/Telegram/SourceFiles/data/data_media_types.cpp
+++ b/Telegram/SourceFiles/data/data_media_types.cpp
@@ -482,8 +482,9 @@ QString MediaFile::chatsListText() const {
 			return lang(lng_in_dlg_video);
 		} else if (_document->isVoiceMessage()) {
 			return lang(lng_in_dlg_audio);
-		} else if (!_document->filename().isEmpty()) {
-			return _document->filename();
+		} else if (const auto name = _document->composeNameString();
+				!name.isEmpty()) {
+			return name;
 		} else if (_document->isAudioFile()) {
 			return lang(lng_in_dlg_audio_file);
 		}

--- a/Telegram/SourceFiles/window/notifications_manager_default.cpp
+++ b/Telegram/SourceFiles/window/notifications_manager_default.cpp
@@ -676,7 +676,7 @@ void Notification::updateNotifyDisplay() {
 				if (_author) {
 					itemTextCache.setText(st::dialogsTextStyle, _author->name);
 					p.setPen(st::dialogsTextFgService);
-					itemTextCache.drawElided(p, r.left(), r.top(), r.width(), st::dialogsTextFont->height);
+					itemTextCache.drawElided(p, r.left(), r.top(), r.width());
 					r.setTop(r.top() + st::dialogsTextFont->height);
 				}
 				p.setPen(st::dialogsTextFg);

--- a/Telegram/gyp/linux_glibc_wraps.gyp
+++ b/Telegram/gyp/linux_glibc_wraps.gyp
@@ -14,7 +14,7 @@
     'sources': [
       '../SourceFiles/platform/linux/linux_glibc_wraps.c',
     ],
-    'conditions': [[ '"<!(uname -p)" == "x86_64" or "<!(uname -p)" == "aarch64"', {
+    'conditions': [[ '"<!(uname -m)" == "x86_64" or "<!(uname -m)" == "aarch64"', {
       'sources': [
         '../SourceFiles/platform/linux/linux_glibc_wraps_64.c',
       ],

--- a/Telegram/gyp/settings_linux.gypi
+++ b/Telegram/gyp/settings_linux.gypi
@@ -25,7 +25,7 @@
         ],
       },
       'conditions': [
-        [ '"<!(uname -p)" == "x86_64" or "<!(uname -p)" == "aarch64"', {
+        [ '"<!(uname -m)" == "x86_64" or "<!(uname -m)" == "aarch64"', {
           'defines': [
             'Q_OS_LINUX64',
           ],


### PR DESCRIPTION
This is required because uname -p actually returns "unknown" for some hardware. The uname help documents this by stating that -p is non-portable. The -m flag is the one to use.