### PR TITLE
Update upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,15 @@ ipch/
 project.xcworkspace
 xcuserdata
 
+parts
+prime
+stage
+*.snap
+.snapcraft
+/snap/gui/*.png
+/snap/gui/*.desktop
+/snap/plugins/__pycache__
+
 /Telegram/*.user.*
 *.pro.user
 /Linux/

--- a/Telegram/Patches/qtbase_5_6_2.diff
+++ b/Telegram/Patches/qtbase_5_6_2.diff
@@ -252,6 +252,43 @@ index 41834b21ae..8cdf4ab145 100644
                          if (value == WSAEADDRNOTAVAIL) {
                              setError(QAbstractSocket::NetworkError, AddressNotAvailableErrorString);
                              socketState = QAbstractSocket::UnconnectedState;
+diff --git a/src/platformsupport/dbustray/qdbustrayicon.cpp b/src/platformsupport/dbustray/qdbustrayicon.cpp
+index 4d6e707..9bdb0be 100644
+--- a/src/platformsupport/dbustray/qdbustrayicon.cpp
++++ b/src/platformsupport/dbustray/qdbustrayicon.cpp
+@@ -58,9 +58,18 @@ QT_BEGIN_NAMESPACE
+ 
+ Q_LOGGING_CATEGORY(qLcTray, "qt.qpa.tray")
+ 
++static QString cachePath()
++{
++    QString xdgCache = QString::fromUtf8(getenv("XDG_CACHE_HOME"));
++    if (xdgCache.isEmpty()) {
++        xdgCache = QDir::cleanPath(QDir::homePath() + QStringLiteral("/.cache"));
++    }
++    return xdgCache;
++}
++
+ static const QString KDEItemFormat = QStringLiteral("org.kde.StatusNotifierItem-%1-%2");
+ static const QString KDEWatcherService = QStringLiteral("org.kde.StatusNotifierWatcher");
+-static const QString TempFileTemplate =  QDir::tempPath() + QStringLiteral("/qt-trayicon-XXXXXX.png");
++static const QString TempFileTemplate = cachePath() + QStringLiteral("/qt-trayicon-XXXXXX.png");
+ static const QString XdgNotificationService = QStringLiteral("org.freedesktop.Notifications");
+ static const QString XdgNotificationPath = QStringLiteral("/org/freedesktop/Notifications");
+ static const QString DefaultAction = QStringLiteral("default");
+@@ -151,6 +160,12 @@ QTemporaryFile *QDBusTrayIcon::tempIcon(const QIcon &icon)
+         uint pid = session.interface()->servicePid(KDEWatcherService).value();
+         QString processName = QLockFilePrivate::processNameByPid(pid);
+         necessary = processName.endsWith(QStringLiteral("indicator-application-service"));
++        if (!necessary) {
++            QString xdgDesktop = QString::fromUtf8(getenv("XDG_CURRENT_DESKTOP"));
++            QStringList desktops = xdgDesktop.toLower().split(QLatin1Char(':'));
++            necessary = desktops.contains(QStringLiteral("unity")) ||
++                        desktops.contains(QStringLiteral("ubuntu"));
++        }
+         necessity_checked = true;
+     }
+     if (!necessary)
 diff --git a/src/platformsupport/fontdatabases/basic/qbasicfontdatabase.cpp b/src/platformsupport/fontdatabases/basic/qbasicfontdatabase.cpp
 index 728b166b71..1dc64593e1 100644
 --- a/src/platformsupport/fontdatabases/basic/qbasicfontdatabase.cpp

--- a/snap/plugins/x-autotools-subsource.py
+++ b/snap/plugins/x-autotools-subsource.py
@@ -1,0 +1,66 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Author: Marco Trevisan <marco@ubuntu.com>
+# Copyright (C) 2017-2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import snapcraft
+
+from snapcraft.internal import sources
+from snapcraft.plugins import autotools
+
+class Dict2Object(object):
+    def __init__(self, d):
+        for k, v in d.items():
+            setattr(self, k.replace('-', '_'), v)
+
+
+class AutotoolsSubsourcePlugin(autotools.AutotoolsPlugin):
+
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+
+        schema['properties']['sub-sources'] = {
+            'type': 'array',
+            'minitems': 0,
+            'uniqueItems': True,
+            'items': {
+                'type': 'object',
+                'additionalProperties': True,
+            },
+            'default': [],
+        }
+
+        return schema
+
+    @classmethod
+    def get_pull_properties(cls):
+        return [
+            'sub-sources',
+        ]
+
+    def pull(self):
+        super().pull()
+
+        for src in self.options.sub_sources:
+            [name] = src.keys()
+            [values] = src.values()
+
+            if 'source' in values:
+                dest = values['dest'] if 'dest' in values else ''
+                sources.get(os.path.join(self.sourcedir, dest),
+                    os.path.join(self.build_basedir, dest),
+                    Dict2Object(values))

--- a/snap/plugins/x-gyp-cmake.py
+++ b/snap/plugins/x-gyp-cmake.py
@@ -1,0 +1,100 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Author: Marco Trevisan <marco@ubuntu.com>
+# Copyright (C) 2017-2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import snapcraft
+
+from snapcraft.plugins import cmake
+
+
+class GypCMakePlugin(cmake.CMakePlugin):
+    """A basic plugin for snapcraft that generates CMake files from gyp"""
+
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+
+        schema['properties']['gyp-file'] = {
+            'type': 'string'
+        }
+
+        schema['properties']['build-type'] = {
+            'type': 'string',
+            'default': 'Release',
+            'enum': ['Debug', 'Release'],
+        }
+
+        schema['properties']['environment'] = {
+            'type': 'array',
+            'minitems': 0,
+            'uniqueItems': True,
+            'items': {
+                'type': 'object',
+                'minitems': 0,
+                'uniqueItems': True,
+                'items': {
+                    'type': 'string',
+                },
+            },
+            'default': [],
+        }
+
+        schema['required'].append('gyp-file')
+
+        schema['build-properties'].extend([
+            'build-type',
+            'gyp-file',
+        ])
+
+        return schema
+
+    def __init__(self, name, options, project):
+        super().__init__(name, options, project)
+        self.build_packages.extend([
+            'binutils',
+            'python',
+        ])
+        self.builddir = os.path.join(
+            self.build_basedir, 'out', self.options.build_type)
+
+    def build(self):
+        env = self._build_environment()
+        gyp_path = os.path.join(self.sourcedir, os.path.dirname(self.options.gyp_file))
+
+        for environ in self.options.environment:
+            [env_name] = list(environ)
+            env[env_name] = str(environ[env_name])
+
+        if not os.path.exists(os.path.join(self.builddir, 'CMakeLists.txt')):
+            gyp_command = ['gyp'] + self.options.configflags + ['--format=cmake']
+            gyp_command.append('--generator-output={}'.format(self.build_basedir))
+            gyp_command.append(os.path.basename(self.options.gyp_file))
+            self.run(gyp_command, cwd=gyp_path)
+
+        if not os.path.exists(os.path.join(self.builddir, 'Makefile')):
+            self.run(['cmake', '.'], env=env)
+
+        self.make(env=env)
+
+        if self.options.artifacts and self.options.build_type == 'Release':
+            for artifact in self.options.artifacts:
+                dest = os.path.join(self.installdir, artifact)
+                if os.path.isfile(dest):
+                    mime_type = self.run_output(
+                        'file --mime-type -b {}'.format(dest).split())
+                    if 'application/x-executable' in mime_type:
+                        self.run(['strip', dest])

--- a/snap/plugins/x-patched-python.py
+++ b/snap/plugins/x-patched-python.py
@@ -1,0 +1,65 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Author: Marco Trevisan <marco@ubuntu.com>
+# Copyright (C) 2017-2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import snapcraft
+import requests
+
+from snapcraft.plugins import python
+
+class PatchedPythonPlugin(python.PythonPlugin):
+
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+
+        schema['properties']['patches'] = {
+            'type': 'array',
+            'minitems': 0,
+            'uniqueItems': True,
+            'items': {
+                'type': 'string',
+            },
+            'default': [],
+        }
+
+        schema['pull-properties'].extend([
+            'patches',
+        ])
+
+        return schema
+
+    def pull(self):
+        super().pull()
+
+        for patch in self.options.patches:
+            patch_name = os.path.basename(patch)
+            patch_stamp = os.path.join(
+                self.sourcedir, '.snapcraft-patched-{}'.format(patch_name))
+
+            if not os.path.exists(patch_stamp):
+                if os.path.exists(patch):
+                    patch_file = os.path.join(os.getcwd(), patch)
+                else:
+                    patch_file = os.path.join(
+                        self.sourcedir, 'snapcraft-patch-{}'.format(patch_name))
+                    with open(patch_file, 'wb') as file:
+                        file.write(requests.get(patch).content)
+
+                patch_cmd = 'git apply -v3 {}'.format(patch_file).split()
+                self.run(patch_cmd, cwd=self.sourcedir)
+                open(patch_stamp, 'a').close()

--- a/snap/plugins/x-qtbuilder.py
+++ b/snap/plugins/x-qtbuilder.py
@@ -1,0 +1,204 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Author: Marco Trevisan <marco@ubuntu.com>
+# Copyright (C) 2017-2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import snapcraft
+
+from snapcraft.plugins import make
+
+class QtBuilderPlugin(make.MakePlugin):
+
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+
+        schema['properties']['configflags'] = {
+            'type': 'array',
+            'minitems': 1,
+            'uniqueItems': False,
+            'items': {
+                'type': 'string',
+            },
+            'default': [],
+        }
+
+        schema['properties']['qt-source-git'] = {
+            'type': 'string'
+        }
+
+        schema['properties']['qt-source-depth'] = {
+            'type': 'integer',
+            'default': 1
+        }
+
+        schema['properties']['qt-version'] = {
+            'type': 'string'
+        }
+
+        schema['properties']['qt-patches-base-url'] = {
+            'type': 'string'
+        }
+
+        schema['properties']['qt-patches-path'] = {
+            'type': 'string'
+        }
+
+        schema['properties']['qt-submodules'] = {
+            'type': 'array',
+            'minitems': 0,
+            'uniqueItems': True,
+            'items': {
+                'type': 'string',
+            },
+            'default': [],
+        }
+
+        schema['properties']['qt-extra-plugins'] = {
+            'type': 'array',
+            'minitems': 0,
+            'uniqueItems': True,
+            'items': {
+                'type': 'object',
+                'minitems': 0,
+                'uniqueItems': True,
+                'items': {
+                    'type': 'string',
+                },
+            },
+            'default': [],
+        }
+
+        schema['properties']['environment'] = {
+            'type': 'array',
+            'minitems': 0,
+            'uniqueItems': True,
+            'items': {
+                'type': 'object',
+                'minitems': 0,
+                'uniqueItems': True,
+                'items': {
+                    'type': 'string',
+                },
+            },
+            'default': [],
+        }
+
+        schema['required'].append('qt-source-git')
+
+        schema['build-properties'].append('configflags')
+
+        return schema
+
+    @classmethod
+    def get_pull_properties(cls):
+        return [
+            'qt-version',
+            'qt-patches-base-url',
+            'qt-patches-path',
+            'qt-submodules',
+            'qt-extra-plugins',
+        ]
+
+    def __init__(self, name, options, project):
+        super().__init__(name, options, project)
+        self.build_packages.extend(['g++', 'patch', 'perl', 'wget'])
+        self.options.source_depth = self.options.qt_source_depth
+
+        if self.options.qt_version:
+            if self.options.qt_version[0] == 'v':
+                self.options.source_branch = self.options.qt_version
+                self.options.qt_version = self.options.qt_version[1:]
+            else:
+                self.options.source_branch = '.'.join(
+                    self.options.qt_version.split('.')[:-1])
+
+
+    def pull(self):
+        if not os.path.exists(os.path.join(self.sourcedir, '.git')) or \
+           not os.path.exists(os.path.join(self.sourcedir, 'init-repository')):
+            shutil.rmtree(self.sourcedir, ignore_errors=True)
+            command = 'git clone {} {}'.format(
+                self.options.qt_source_git, self.sourcedir).split()
+            if self.options.source_branch:
+                command.extend(['--branch', str(self.options.source_branch)])
+            if self.options.source_depth:
+                command.extend(['--depth', str(self.options.source_depth)])
+
+            self.run(command)
+
+        command = 'perl init-repository --branch -f'.split()
+        if len(self.options.qt_submodules):
+            command.extend('--module-subset={}'.format(
+                ','.join(self.options.qt_submodules)).split())
+        self.run(command, cwd=self.sourcedir)
+
+        if self.options.qt_version:
+            self.run("git submodule foreach git checkout v{}".format(
+                self.options.qt_version).split(), self.sourcedir)
+
+        patch_file_template = '${{name}}{}.diff'.format(
+            '_' + self.options.qt_version.replace('.', '_') \
+            if self.options.qt_version else '')
+
+        if self.options.qt_patches_base_url:
+            patch_uri_template = '{}/{}'.format(
+                self.options.qt_patches_base_url, patch_file_template)
+
+            patch_cmd = 'git submodule foreach -q'.split() + \
+                        ['[ -e {touch_file} ] || ' \
+                        'wget -q -O - {patch_uri_template} | patch -p1 && ' \
+                        'touch {touch_file}'.format(
+                            patch_uri_template=patch_uri_template,
+                            touch_file='.snapcraft-qt-patched')]
+
+            self.run(patch_cmd, cwd=self.sourcedir)
+
+        if self.options.qt_patches_path:
+            patch_path_template = os.path.join(
+                os.getcwd(), self.options.qt_patches_path, patch_file_template)
+
+            patch_cmd = 'git submodule foreach -q'.split() + \
+                        ['[ -e {patch} ] && git apply -v3 {patch} || true'.format(
+                            patch=patch_path_template)]
+
+            self.run(patch_cmd, cwd=self.sourcedir)
+
+        for extra_plugin in self.options.qt_extra_plugins:
+            [framework] = list(extra_plugin)
+
+            final_path = os.path.join(self.sourcedir, 'qtbase', 'src',
+                'plugins', framework)
+
+            for repo in extra_plugin[framework]:
+                repo_path = os.path.basename(repo)
+                if repo_path.endswith('.git'):
+                    repo_path = repo_path[:-4]
+
+                if not os.path.exists(os.path.join(final_path, repo_path)):
+                    command = 'git clone {}'.format(repo).split()
+                    self.run(command, cwd=final_path)
+
+    def build(self):
+        env = {}
+
+        for environ in self.options.environment:
+            [env_name] = list(environ)
+            env[env_name] = str(environ[env_name])
+
+        self.run(['./configure'] + self.options.configflags, env=env)
+        super().build()

--- a/snap/scripts/telegram-launch
+++ b/snap/scripts/telegram-launch
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+default_downloaddir="$SNAP_USER_DATA/Telegram Desktop"
+
+if [ -d "$default_downloaddir" ] && [ ! -L "$default_downloaddir" ]; then
+  dest_downloaddir="$SNAP_USER_COMMON/$(basename "$default_downloaddir")"
+  if [ -d "$dest_downloaddir" ]; then
+    mv -v "$default_downloaddir/*" "$dest_downloaddir/"
+    rmdir "$default_downloaddir"
+  else
+    mv -v "$default_downloaddir" "$SNAP_USER_COMMON"
+  fi
+  ln -sv "$dest_downloaddir" "$default_downloaddir"
+fi
+
+default_im_module="xim"
+
+if [ -n "$TELEGRAM_QT_IM_MODULE" ]; then
+  export QT_IM_MODULE="$TELEGRAM_QT_IM_MODULE"
+elif [ -z "$QT_IM_MODULE" ] || [ "$QT_IM_MODULE" == "ibus" ]; then
+  export QT_IM_MODULE="$default_im_module"
+fi
+
+exec desktop-launch Telegram $*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,415 @@
+name: telegram-desktop
+version: git
+adopt-info: telegram
+description: |
+  Telegram is a popular messaging protocol with encryption and security as
+  its key focus.
+
+  Fast and secure desktop app, perfectly synced with your mobile phone.
+
+grade: stable
+confinement: strict
+
+version-script: |
+  set -x
+  version_file=Telegram/build/version
+  version=$(sed -n "s/AppVersionStr[ ]\+\(.*\)\+/\1/p" $version_file)
+  alpha=$(sed -n "s/AlphaChannel[ ]\+\(.*\)\+/\1/p" $version_file)
+  beta=$(sed -n "s/BetaVersion[ ]\+\(.*\)\+/\1/p" $version_file)
+
+  if [ "$alpha" != "0" ]; then
+    version="$version-alpha"
+  elif [ "$beta" != "0" ]; then
+    version="$version-beta"
+  fi
+
+  version="${version}$(git describe --tags | sed 's,^v[^-]\+,,')"
+
+  echo $version
+
+apps:
+  telegram-desktop:
+    command: telegram-launch
+    common-id: org.telegram.desktop
+    environment:
+      DISABLE_WAYLAND: 1
+      WAYLAND_DISPLAY: no-display
+      QTCOMPOSE: $SNAP/usr/share/X11/locale
+      HOME: "$SNAP_USER_COMMON"
+    plugs:
+      - desktop
+      - desktop-legacy
+      - gsettings
+      - home
+      - network
+      - network-bind
+      - network-manager
+      - pulseaudio
+      - removable-media
+      - unity7
+
+parts:
+  telegram:
+    plugin: gyp-cmake
+    source: .
+    source-type: git
+    parse-info: [lib/xdg/telegramdesktop.appdata.xml]
+    build-packages:
+      - libappindicator-dev
+      - libappindicator3-dev
+      - libexif-dev
+      - libicu-dev
+      - liblzma-dev
+      - libssl-dev
+      - libunity-dev
+      - zlib1g-dev
+    gyp-file: Telegram/gyp/Telegram.gyp
+    build-type: 'Release'
+    artifacts: ['Telegram']
+    environment:
+      - CC: gcc-7
+      - CXX: g++-7
+    organize:
+      Telegram: bin/Telegram
+    configflags:
+      - -Dlinux_path_breakpad=$SNAPCRAFT_STAGE
+      - -Dlinux_path_range=$SNAPCRAFT_STAGE/range-v3
+      - -Dlinux_path_ffmpeg=$SNAPCRAFT_STAGE
+      - -Dlinux_path_libexif_lib=$SNAPCRAFT_STAGE
+      - -Dlinux_path_openal=$SNAPCRAFT_STAGE
+      - -Dlinux_path_opus_include=$SNAPCRAFT_STAGE/include/opus
+      - -Dlinux_path_qt=$SNAPCRAFT_STAGE
+      - -Dlinux_path_va=$SNAPCRAFT_STAGE
+      - -Dlinux_path_vdpau=$SNAPCRAFT_STAGE
+      - -Dlinux_path_xkbcommon=$SNAPCRAFT_STAGE
+      - -Dlinux_lib_ssl=-lssl
+      - -Dlinux_lib_crypto=-lcrypto
+      - -Dlinux_lib_icu=-licuuc -licutu -licui18n
+      - -Dbuild_defines=TDESKTOP_DISABLE_AUTOUPDATE,
+                        TDESKTOP_DISABLE_REGISTER_CUSTOM_SCHEME,
+                        TDESKTOP_DISABLE_DESKTOP_FILE_GENERATION
+      - --depth=.
+    override-build: |
+      set -xe
+      snapcraftctl build
+      snap_gui=$SNAPCRAFT_STAGE/../snap/gui
+      mkdir -vp $snap_gui
+      cp -v lib/xdg/telegramdesktop.desktop $snap_gui
+      cp -v Telegram/Resources/art/icon512@2x.png $snap_gui/icon.png
+      sed -i "s|^Icon=.*|Icon=\${SNAP}/meta/gui/icon.png|g" $snap_gui/telegramdesktop.desktop
+      echo "Keywords=tg;chat;im;messaging;messenger;" >> $snap_gui/telegramdesktop.desktop
+    after:
+      - breakpad
+      - ffmpeg
+      - gyp
+      - libva
+      - openal
+      - qt
+      - range-v3
+      - gcc7
+
+  telegram-launcher:
+    plugin: dump
+    source: snap/scripts
+    organize:
+      telegram-launch: bin/telegram-launch
+
+  desktop-integration:
+    plugin: nil
+    stage-packages:
+      - libappindicator3-1
+      - libnotify4
+      - libpulse0
+      - libunity9
+    after: [desktop-gtk3]
+    stage: [-./usr/share/fonts/**]
+
+  desktop-gtk3:
+    stage: [-./usr/share/fonts/**]
+    override-build: |
+      set -xe
+      snapcraftctl build
+      export XDG_DATA_DIRS=$SNAPCRAFT_PART_INSTALL/usr/share
+      update-mime-database $SNAPCRAFT_PART_INSTALL/usr/share/mime
+
+      for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
+        if [ -f $dir/index.theme ]; then
+          gtk-update-icon-cache-3.0 -q $dir
+        fi
+      done
+
+  libva:
+    source: https://github.com/01org/libva.git
+    source-depth: 1
+    plugin: autotools
+    build-packages:
+      - libdrm-dev
+      - libegl1-mesa-dev
+      - libgl1-mesa-dev
+      - libx11-dev
+      - libxext-dev
+      - libxfixes-dev
+    configflags:
+      - --enable-static
+    prime: [-./*]
+
+  libvdpau:
+    source: git://anongit.freedesktop.org/vdpau/libvdpau
+    source-depth: 1
+    plugin: autotools
+    build-packages:
+      - libx11-dev
+      - x11proto-dri2-dev
+      - libxext-dev
+    configflags:
+      - --enable-static
+    prime: [-./*]
+
+  opus:
+    source: https://github.com/xiph/opus.git
+    source-depth: 1
+    source-branch: v1.2.1
+    plugin: autotools
+    prime: [-./*]
+
+  ffmpeg:
+    source: https://github.com/FFmpeg/FFmpeg.git
+    source-depth: 1
+    source-branch: release/3.4
+    plugin: autotools
+    build-packages:
+      - libass-dev
+      - libfreetype6-dev
+      - libgpac-dev
+      - liblzma-dev
+      - libsdl1.2-dev
+      - libtheora-dev
+      - libtool
+      - libvorbis-dev
+      - libxcb1-dev
+      - libxcb-shm0-dev
+      - libxcb-xfixes0-dev
+      - pkg-config
+      - texi2html
+      - yasm
+      - zlib1g-dev
+    configflags:
+      - --prefix=/
+      - --disable-debug
+      - --disable-programs
+      - --disable-doc
+      - --disable-everything
+      - --enable-gpl
+      - --enable-version3
+      - --enable-libopus
+      - --enable-decoder=aac
+      - --enable-decoder=aac_latm
+      - --enable-decoder=aasc
+      - --enable-decoder=flac
+      - --enable-decoder=gif
+      - --enable-decoder=h264
+      - --enable-decoder=h264_vdpau
+      - --enable-decoder=mp1
+      - --enable-decoder=mp1float
+      - --enable-decoder=mp2
+      - --enable-decoder=mp2float
+      - --enable-decoder=mp3
+      - --enable-decoder=mp3adu
+      - --enable-decoder=mp3adufloat
+      - --enable-decoder=mp3float
+      - --enable-decoder=mp3on4
+      - --enable-decoder=mp3on4float
+      - --enable-decoder=mpeg4
+      - --enable-decoder=mpeg4_vdpau
+      - --enable-decoder=msmpeg4v2
+      - --enable-decoder=msmpeg4v3
+      - --enable-decoder=opus
+      - --enable-decoder=vorbis
+      - --enable-decoder=wavpack
+      - --enable-decoder=wmalossless
+      - --enable-decoder=wmapro
+      - --enable-decoder=wmav1
+      - --enable-decoder=wmav2
+      - --enable-decoder=wmavoice
+      - --enable-encoder=libopus
+      - --enable-hwaccel=h264_vaapi
+      - --enable-hwaccel=h264_vdpau
+      - --enable-hwaccel=mpeg4_vaapi
+      - --enable-hwaccel=mpeg4_vdpau
+      - --enable-parser=aac
+      - --enable-parser=aac_latm
+      - --enable-parser=flac
+      - --enable-parser=h264
+      - --enable-parser=mpeg4video
+      - --enable-parser=mpegaudio
+      - --enable-parser=opus
+      - --enable-parser=vorbis
+      - --enable-demuxer=aac
+      - --enable-demuxer=flac
+      - --enable-demuxer=gif
+      - --enable-demuxer=h264
+      - --enable-demuxer=mov
+      - --enable-demuxer=mp3
+      - --enable-demuxer=ogg
+      - --enable-demuxer=wav
+      - --enable-muxer=ogg
+      - --enable-muxer=opus
+    after:
+      - libva
+      - libvdpau
+      - opus
+    prime: [-./*]
+
+  openal:
+    source: https://github.com/kcat/openal-soft.git
+    source-depth: 1
+    source-branch: v1.18
+    plugin: cmake
+    build-packages:
+      - oss4-dev
+      - portaudio19-dev
+    configflags:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DALSOFT_EXAMPLES=OFF
+      - -DALSOFT_TESTS=OFF
+      - -DALSOFT_UTILS=OFF
+      - -DLIBTYPE=STATIC
+    after:
+      - ffmpeg
+    prime: [-./*]
+
+  libxkbcommon:
+    source: https://github.com/xkbcommon/libxkbcommon.git
+    source-depth: 1
+    plugin: autotools
+    build-packages:
+      - xutils-dev
+      - bison
+      - python-xcbgen
+    configflags:
+      - --disable-x11
+    prime: [-./*]
+
+  qt:
+    plugin: qtbuilder
+    qt-version: 5.6.2
+    qt-source-git: https://code.qt.io/qt/qt5.git
+    qt-submodules: ['qtbase', 'qtimageformats']
+    qt-patches-path: Telegram/Patches
+    qt-extra-plugins:
+      - platforminputcontexts:
+        - https://github.com/telegramdesktop/fcitx.git
+        - https://github.com/telegramdesktop/hime.git
+    environment:
+      - CC: gcc-7
+      - CXX: g++-7
+      - QMAKE_CC: gcc-7
+      - QMAKE_CXX: g++-7
+    build-packages:
+      - libasound2-dev
+      - libdbusmenu-glib-dev
+      - libffi-dev
+      - liblzma-dev
+      - libpulse-dev
+      - libssl-dev
+      - libx11-xcb-dev
+      - libxcb-icccm4-dev
+      - libxcb-image0-dev
+      - libxcb-keysyms1-dev
+      - libxcb-randr0-dev
+      - libxcb-render-util0-dev
+      - libxcb-sync-dev
+      - libxcb-util0-dev
+      - libxcb-xfixes0-dev
+      - libxcb1-dev
+      - libxrender-dev
+    configflags:
+      - -prefix
+      - $SNAPCRAFT_STAGE
+      - -release
+      - -force-debug-info
+      - -opensource
+      - -confirm-license
+      - -qt-zlib
+      - -qt-libpng
+      - -qt-libjpeg
+      - -qt-freetype
+      - -qt-harfbuzz
+      - -qt-pcre
+      - -qt-xcb
+      - -qt-xkbcommon-x11
+      - -no-gstreamer
+      - -no-gtkstyle
+      - -no-mirclient
+      - -no-opengl
+      - -static
+      - -dbus-runtime
+      - -openssl-linked
+      - -nomake
+      - examples
+      - -nomake
+      - tests
+    after:
+      - libxkbcommon
+      - gcc7
+    prime: [-./*]
+
+  breakpad:
+    plugin: autotools-subsource
+    source: https://chromium.googlesource.com/breakpad/breakpad
+    source-type: git
+    source-commit: bc8fb886
+    sub-sources:
+      - linux-syscall-support:
+          dest: src/third_party/lss
+          source: https://chromium.googlesource.com/linux-syscall-support
+          source-type: git
+          source-commit: a91633d1
+    prime: [-./*]
+
+  range-v3:
+    source: https://github.com/ericniebler/range-v3.git
+    source-depth: 1
+    plugin: nil
+    override-build: |
+      set -x
+      snapcraftctl build
+      mkdir $SNAPCRAFT_PART_INSTALL/range-v3
+      cp -rv * $SNAPCRAFT_PART_INSTALL/range-v3
+    prime: [-./*]
+
+  gyp:
+    plugin: patched-python
+    source: https://chromium.googlesource.com/external/gyp
+    source-type: git
+    source-commit: 702ac58e47
+    python-version: python2
+    patches:
+      - Telegram/Patches/gyp.diff
+    prime: [-./*]
+
+  # Since this is supposed to be built against ubuntu 16.04, we need to manually
+  # install gcc7, and this is a workaround to achieve this.
+  # This part can be safely removed when build.snapcraft.io will allow
+  # to build against 18.04.
+  gcc7:
+    plugin: nil
+    build-packages:
+      - libmpc-dev
+      - libcloog-ppl-dev
+    override-pull: |
+      set -x
+      echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu xenial main" | \
+            sudo tee /etc/apt/sources.list.d/ubuntu-toolchain-r.list
+      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
+      sudo apt-get update \
+        -o Dir::Etc::sourcelist="sources.list.d/ubuntu-toolchain-r.list" \
+        -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+      snapcraftctl pull
+    override-build: |
+      set -x
+      snapcraftctl build
+      sudo apt install gcc-7 g++-7 -o Debug::pkgProblemResolver=yes --no-install-recommends -y
+      sudo apt-mark auto gcc-7 g++-7
+      sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r.list
+    prime: [-./*]


### PR DESCRIPTION
* qtbuilder: inherit from make plugin instead of autotools

* qtbuilder: update to properly support snapcraft 2.23

We don't use the default 'source' property as it will recursively download
all the submodules and we don't want that.

Implement newer get_pull_properties.

* gyp-cmake: only strip in Release mode and if we've a binary

* telegram-snap: add first basic snapcraft.yaml to build tdesktop from src

We need to build upstream versions of libva, ffmpeg (with opus support),
openal, portaudio with custom flags and patched versions of gyp, and Qt.

This requires some custom plugins for patching sources, mix repos and
new build plugins for qt and gyp+cmake.

* plugins: properly support snapcraft 2.23

Implementing get_pull_properties class methods

* patches: add qt patch for saving tray icon in .cache

TMPDIR overriding isn't needed anymore

* snapcraft: add xdg-open support to open URIs

* snapcraft: move external libraries to desktop-integration part

* snapcraft: set QTCOMPOSE pointing to proper x11-data

* desktop-integration: add libpulse0 to enable voice/video recording / playing

* qtbuilder: add support for local patches that overrides remote ones

* qtbuilder: make qt-version optional

This allows to build upstream git version

* gyp-cmake: inherit from CMakePlugin reusing artifacts + organize

* patched-python: add support for patching using local files

* snapcraft.yaml: use distro's portaudio instead of building ours

* telegram: disable desktop file generation and custuom scheme registration

* snapcraft.yaml: update version to 0.10.20

* .travis.yaml: add support for building using travis

* qtbuilder: add g++ as build packages

* snapcraft: use distro opus version

* snapcraft: lzma for qt and ffmpeg

* snapcraft: add libdbusmenu for qt

* openal: add oss4-dev as build dependency

* travis: test some hacks to speed things up

* Move plugins to new dir

* QtBuilder: add qt-extra-plugins support

To include plugins that are out of the main qt repo

* QtBuilder: generate branch based on qtversion

* GypCMake: allow to define custom environment variables

* snapcraft: set name to 'telegram-desktop'

* snapcraft: add 'network-status' interface to Telegram app

To automatically reconnect

* snapcraft: use prime instead of snap for flitering files

* snacpraft: update dependencies and versions to build against git

* snapcraft: build with GCC-7

hackish solution

* QtBuilder: add environment support

* QtBuilder: add qt-extra-plugins to get_pull_properties

* snapcraft: set name of the app to telegram-desktop too

* snapcraft: build opus from git (v1.2.1)

So it does upstream, let's follow them

* telegram: apply patch to get proper home path from $HOME

* snapcraft: add version-script to generate proper version from upstream

* telegram: simplify the start command

* snapcraft: get rid of snapd-xdg-open

* snapcraft: use gtk3 and unity integration

* qt5: build using gcc7 too

* telegram-desktop: update desktop file

* telegram: add support unity launcher when snapped

We should actually fix this inside libunity

* gcc7: remove toolchain source.list after install

* desktop-integration: add pulse-audio as dependency again

* telegram-desktop: define XCURSOR_PATH to get system cursors

* gui: move files to snap folder

* libtgvoip: don't enable SSE2 in unsupported archs

* snapcraft: add -alpha sufix on versions and do not include git for tags

* telegram: add patch for building in ARM chips

* desktop-integration: include libunity

* telegram-desktop: no need to define XCURSOR_PATH anymore, desktop helper will do

* snapcraft: compile libunity from upstream to get proper launcher integration

Drop custom patch, it's just better to do it here. This means we
go back to upstream telegramdesktop desktop-id too.

* telegram: get desktop file and icon from telegram part source

* snapcraft: improve snap description

* gcc7: not needed to add devscripts or equivs

Unless we try to build gcc7 here, which well... A bit time consuming.

* libunity: use upstream branch (my changes just merged)

* ci: remove travis integration, it takes to long b.s.io does it already

* telegram: don't do unneeded checks in armhf

* telegram: more signed/unsigned char fixes for ARM, ignore errors for now

* telegram: add getclock definitions for ARM

* telegram: arm support, always use signed chars

* telegram: don't need to use signed chars in ARM anymmore

As we've fixed all the issues

* telegram: replace .desktop file icon with snap one, add keywords

* snapcraft: use diversity check on alpha value

* telegram: detect Ubuntu desktop adding support for badges and indicators

* telegram: unset WAYLAND_DISPLAY to get it running properly

* Add a README

* telegram: just add network-observe plug

* snapcraft: add beta detection

* snapcraft: only add network-manager plug, users might connect it

We should actually have a connection-observe plug.

* patches: add patch to use a customizable working dir in debug

* snapcraft: define again QT_IM_MODULE and QTCOMPOSE fix compose key

Setting compose to proper paths will allow to get composition key
working again in snapped QT apps.

* desktop-integration: add indicator-gtk3 and chinese fonts

* desktop-integration: don't snap fonts, use desktop interface

Fonts are now bind-mounted from host by the desktop interface

* patches: apply patches using 3way merge if they fail

* patches: update telegram-arm-support to apply cleanly

* snapcraft: disable wayland using desktop script env

* snapcraft: libunity has been SRU'ed, we can go back to archive version

* patches: update arm support patch

* breakpad: use upstream versions

* telegram, patches: remove upstreamed patches

* patches: disable Werror

It causes failures in some archs, and we don't care much at this
level (for now).

* patches: remove libtgvoip msse2 patch

* Revert "patches: remove libtgvoip msse2 patch"

Not yet in the submodule used by telegram desktop

This reverts commit 2e6f4cc619ee591fdd250cb3b2af4f0330d1c4ca.

* snapcraft: show bash debugging on version script

* desktop-gtk3: update mime database and icon-cache during install

This saves some startup time

* telegram: add gsettings plug

* telegram-launch: use user-common as home and migrate if needed

* Import snap folder from telegram-snap repo

* patches, qtbase: use indicator icon in unity or ubuntu

Patch already applied upstream, remove from snap only

* .gitignore: add snap related files

* telegram-launch: merge downloaded files folder if found

* snap: remove patches not needed for upstream

* snap, patch, libtgvoip: sync with upstream

* telegram-launch: remove default dir after moving download files

* snap: remove libtgvoip patches, we can just update the submodule

The actual module update should be managed in a different
commit though.

* snapcraft: explain why gcc7 part is needed

* snapcraft: update summary text

* qt: no need to build gstreamer, and reorder configflags

* plugins: add copyright informations

* telegram: add common-id and parse-info with AppData

Use the appstream integration that snapcraft now supports.

* openal: use v1.18 branch as upstream does now

* qtbuilder: support tags in versions better

* qtbuilder: use shutil.rmtree to remove files

* telegram: set QT_IM_MODULE only if not set

* telegram: add removable-media plug

* telegram-launch: ignore ibus as input method

And add support for getting it from $TELEGRAM_QT_IM_MODULE env var

* snapcraft: use git describe to get revision

* snapcraft: use override-* stanzas for scriptlets

* snap: exit scriptlets on first error

* snap: remove summary, inherit from AppData

* lib_export: use includes paths as defined per platform