### PR TITLE
Open a pull request

### DIFF
--- a/Telegram/SourceFiles/boxes/connection_box.cpp
+++ b/Telegram/SourceFiles/boxes/connection_box.cpp
@@ -1148,7 +1148,7 @@ object_ptr<Ui::BoxContent> ProxiesBoxController::create() {
 	for (const auto &item : _list) {
 		updateView(item);
 	}
-	return std::move(result);
+	return result;
 }
 
 auto ProxiesBoxController::findById(int id) -> std::vector<Item>::iterator {

--- a/Telegram/SourceFiles/boxes/create_poll_box.cpp
+++ b/Telegram/SourceFiles/boxes/create_poll_box.cpp
@@ -768,7 +768,7 @@ object_ptr<Ui::RpWidget> CreatePollBox::setupContent() {
 		FocusAtEnd(question);
 	}, lifetime());
 
-	return std::move(result);
+	return result;
 }
 
 void CreatePollBox::prepare() {

--- a/Telegram/SourceFiles/boxes/peers/edit_linked_chat_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_linked_chat_box.cpp
@@ -223,7 +223,7 @@ object_ptr<Ui::RpWidget> SetupAbout(
 			tr::now,
 			Ui::Text::WithEntities);
 	}());
-	return std::move(about);
+	return about;
 }
 
 object_ptr<Ui::RpWidget> SetupFooter(

--- a/Telegram/SourceFiles/boxes/peers/edit_participants_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_participants_box.cpp
@@ -1786,7 +1786,7 @@ std::unique_ptr<PeerListRow> ParticipantsBoxController::createRow(
 			row->setActionLink(tr::lng_profile_kick(tr::now));
 		}
 	}
-	return std::move(row);
+	return row;
 }
 
 auto ParticipantsBoxController::computeType(
@@ -1931,7 +1931,7 @@ auto ParticipantsBoxSearchController::saveState() const
 	result->offset = _offset;
 	result->allLoaded = _allLoaded;
 	result->wasLoading = (_requestId != 0);
-	return std::move(result);
+	return result;
 }
 
 void ParticipantsBoxSearchController::restoreState(

--- a/Telegram/SourceFiles/boxes/peers/edit_peer_info_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_peer_info_box.cpp
@@ -478,7 +478,7 @@ object_ptr<Ui::RpWidget> Controller::createTitleEdit() {
 		[=] { submitTitle(); });
 
 	_controls.title = result->entity();
-	return std::move(result);
+	return result;
 }
 
 object_ptr<Ui::RpWidget> Controller::createDescriptionEdit() {
@@ -512,7 +512,7 @@ object_ptr<Ui::RpWidget> Controller::createDescriptionEdit() {
 		[=] { submitDescription(); });
 
 	_controls.description = result->entity();
-	return std::move(result);
+	return result;
 }
 
 object_ptr<Ui::RpWidget> Controller::createManageGroupButtons() {
@@ -526,7 +526,7 @@ object_ptr<Ui::RpWidget> Controller::createManageGroupButtons() {
 
 	fillManageSection();
 
-	return std::move(result);
+	return result;
 }
 
 object_ptr<Ui::RpWidget> Controller::createStickersEdit() {
@@ -564,7 +564,7 @@ object_ptr<Ui::RpWidget> Controller::createStickersEdit() {
 		Ui::show(Box<StickersBox>(channel), Ui::LayerOption::KeepOther);
 	});
 
-	return std::move(result);
+	return result;
 }
 
 bool Controller::canEditInformation() const {

--- a/Telegram/SourceFiles/boxes/peers/edit_peer_type_box.cpp
+++ b/Telegram/SourceFiles/boxes/peers/edit_peer_type_box.cpp
@@ -364,7 +364,7 @@ object_ptr<Ui::RpWidget> Controller::createUsernameEdit() {
 	const auto shown = (_controls.privacy->value() == Privacy::HasUsername);
 	result->toggle(shown, anim::type::instant);
 
-	return std::move(result);
+	return result;
 }
 
 void Controller::privacyChanged(Privacy value) {
@@ -630,7 +630,7 @@ object_ptr<Ui::RpWidget> Controller::createInviteLinkEdit() {
 
 	observeInviteLink();
 
-	return std::move(result);
+	return result;
 }
 
 void Controller::refreshEditInviteLink() {
@@ -692,7 +692,7 @@ object_ptr<Ui::RpWidget> Controller::createInviteLinkCreate() {
 
 	observeInviteLink();
 
-	return std::move(result);
+	return result;
 }
 
 void Controller::refreshCreateInviteLink() {

--- a/Telegram/SourceFiles/calls/calls_box_controller.cpp
+++ b/Telegram/SourceFiles/calls/calls_box_controller.cpp
@@ -404,8 +404,7 @@ BoxController::Row *BoxController::rowForItem(not_null<const HistoryItem*> item)
 
 std::unique_ptr<PeerListRow> BoxController::createRow(
 		not_null<HistoryItem*> item) const {
-	auto row = std::make_unique<Row>(item);
-	return std::move(row);
+	return std::make_unique<Row>(item);
 }
 
 } // namespace Calls

--- a/Telegram/SourceFiles/chat_helpers/emoji_list_widget.cpp
+++ b/Telegram/SourceFiles/chat_helpers/emoji_list_widget.cpp
@@ -427,7 +427,7 @@ object_ptr<TabbedSelector::InnerFooter> EmojiListWidget::createFooter() {
 	Expects(_footer == nullptr);
 	auto result = object_ptr<Footer>(this);
 	_footer = result;
-	return std::move(result);
+	return result;
 }
 
 template <typename Callback>

--- a/Telegram/SourceFiles/chat_helpers/gifs_list_widget.cpp
+++ b/Telegram/SourceFiles/chat_helpers/gifs_list_widget.cpp
@@ -178,7 +178,7 @@ object_ptr<TabbedSelector::InnerFooter> GifsListWidget::createFooter() {
 
 	auto result = object_ptr<Footer>(this);
 	_footer = result;
-	return std::move(result);
+	return result;
 }
 
 void GifsListWidget::visibleTopBottomUpdated(

--- a/Telegram/SourceFiles/chat_helpers/stickers.cpp
+++ b/Telegram/SourceFiles/chat_helpers/stickers.cpp
@@ -891,7 +891,7 @@ std::optional<std::vector<not_null<EmojiPtr>>> GetEmojiListFromSet(
 		if (result.empty()) {
 			return std::nullopt;
 		}
-		return std::move(result);
+		return result;
 	}
 	return std::nullopt;
 }

--- a/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp
+++ b/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp
@@ -878,7 +878,7 @@ object_ptr<TabbedSelector::InnerFooter> StickersListWidget::createFooter() {
 
 	auto result = object_ptr<Footer>(this);
 	_footer = result;
-	return std::move(result);
+	return result;
 }
 
 void StickersListWidget::visibleTopBottomUpdated(

--- a/Telegram/SourceFiles/chat_helpers/tabbed_section.cpp
+++ b/Telegram/SourceFiles/chat_helpers/tabbed_section.cpp
@@ -20,7 +20,7 @@ object_ptr<Window::SectionWidget> TabbedMemento::createWidget(
 		const QRect &geometry) {
 	auto result = object_ptr<TabbedSection>(parent, controller);
 	result->setGeometry(geometry);
-	return std::move(result);
+	return result;
 }
 
 TabbedSection::TabbedSection(

--- a/Telegram/SourceFiles/history/admin_log/history_admin_log_section.cpp
+++ b/Telegram/SourceFiles/history/admin_log/history_admin_log_section.cpp
@@ -97,7 +97,7 @@ object_ptr<Window::SectionWidget> SectionMemento::createWidget(
 	}
 	auto result = object_ptr<Widget>(parent, controller, _channel);
 	result->setInternalState(geometry, this);
-	return std::move(result);
+	return result;
 }
 
 FixedBar::FixedBar(
@@ -365,7 +365,7 @@ void Widget::setupShortcuts() {
 std::unique_ptr<Window::SectionMemento> Widget::createMemento() {
 	auto result = std::make_unique<SectionMemento>(channel());
 	saveState(result.get());
-	return std::move(result);
+	return result;
 }
 
 void Widget::saveState(not_null<SectionMemento*> memento) {

--- a/Telegram/SourceFiles/history/feed/history_feed_section.cpp
+++ b/Telegram/SourceFiles/history/feed/history_feed_section.cpp
@@ -59,7 +59,7 @@ object_ptr<Window::SectionWidget> Memento::createWidget(
 	}
 	auto result = object_ptr<Widget>(parent, controller, _feed);
 	result->setInternalState(geometry, this);
-	return std::move(result);
+	return result;
 }
 
 Widget::Widget(
@@ -456,7 +456,7 @@ ClickHandlerPtr Widget::listDateLink(not_null<Element*> view) {
 std::unique_ptr<Window::SectionMemento> Widget::createMemento() {
 	auto result = std::make_unique<Memento>(_feed);
 	saveState(result.get());
-	return std::move(result);
+	return result;
 }
 
 void Widget::saveState(not_null<Memento*> memento) {

--- a/Telegram/SourceFiles/history/view/history_view_scheduled_section.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_scheduled_section.cpp
@@ -67,7 +67,7 @@ object_ptr<Window::SectionWidget> ScheduledMemento::createWidget(
 	}
 	auto result = object_ptr<ScheduledWidget>(parent, controller, _history);
 	result->setInternalState(geometry, this);
-	return std::move(result);
+	return result;
 }
 
 ScheduledWidget::ScheduledWidget(
@@ -714,7 +714,7 @@ bool ScheduledWidget::returnTabbedSelector() {
 std::unique_ptr<Window::SectionMemento> ScheduledWidget::createMemento() {
 	auto result = std::make_unique<ScheduledMemento>(history());
 	saveState(result.get());
-	return std::move(result);
+	return result;
 }
 
 void ScheduledWidget::saveState(not_null<ScheduledMemento*> memento) {

--- a/Telegram/SourceFiles/info/channels/info_channels_widget.cpp
+++ b/Telegram/SourceFiles/info/channels/info_channels_widget.cpp
@@ -35,7 +35,7 @@ object_ptr<ContentWidget> Memento::createWidget(
 		parent,
 		controller);
 	result->setInternalState(geometry, this);
-	return std::move(result);
+	return result;
 }
 
 void Memento::setState(std::unique_ptr<SavedState> state) {
@@ -79,7 +79,7 @@ void Widget::setInternalState(
 std::unique_ptr<ContentMemento> Widget::doCreateMemento() {
 	auto result = std::make_unique<Memento>(controller());
 	saveState(result.get());
-	return std::move(result);
+	return result;
 }
 
 void Widget::saveState(not_null<Memento*> memento) {

--- a/Telegram/SourceFiles/info/common_groups/info_common_groups_widget.cpp
+++ b/Telegram/SourceFiles/info/common_groups/info_common_groups_widget.cpp
@@ -33,7 +33,7 @@ object_ptr<ContentWidget> Memento::createWidget(
 		controller,
 		Auth().data().user(userId()));
 	result->setInternalState(geometry, this);
-	return std::move(result);
+	return result;
 }
 
 void Memento::setListState(std::unique_ptr<PeerListState> state) {
@@ -85,7 +85,7 @@ void Widget::setInternalState(
 std::unique_ptr<ContentMemento> Widget::doCreateMemento() {
 	auto result = std::make_unique<Memento>(user()->bareId());
 	saveState(result.get());
-	return std::move(result);
+	return result;
 }
 
 void Widget::saveState(not_null<Memento*> memento) {

--- a/Telegram/SourceFiles/info/feed/info_feed_profile_inner_widget.cpp
+++ b/Telegram/SourceFiles/info/feed/info_feed_profile_inner_widget.cpp
@@ -61,7 +61,7 @@ object_ptr<Ui::RpWidget> InnerWidget::setupContent(
 		_scrollToRequests.fire({ min, max });
 	}, _channels->lifetime());
 
-	return std::move(result);
+	return result;
 }
 
 int InnerWidget::countDesiredHeight() const {

--- a/Telegram/SourceFiles/info/feed/info_feed_profile_widget.cpp
+++ b/Telegram/SourceFiles/info/feed/info_feed_profile_widget.cpp
@@ -35,7 +35,7 @@ object_ptr<ContentWidget> Memento::createWidget(
 		parent,
 		controller);
 	result->setInternalState(geometry, this);
-	return std::move(result);
+	return result;
 }
 
 void Memento::setChannelsState(std::unique_ptr<ChannelsState> state) {
@@ -99,7 +99,7 @@ void Widget::setInternalState(
 std::unique_ptr<ContentMemento> Widget::doCreateMemento() {
 	auto result = std::make_unique<Memento>(controller());
 	saveState(result.get());
-	return std::move(result);
+	return result;
 }
 
 void Widget::saveState(not_null<Memento*> memento) {

--- a/Telegram/SourceFiles/info/info_memento.cpp
+++ b/Telegram/SourceFiles/info/info_memento.cpp
@@ -160,7 +160,7 @@ object_ptr<Window::SectionWidget> Memento::createWidget(
 		wrap,
 		this);
 	result->setGeometry(geometry);
-	return std::move(result);
+	return result;
 }
 
 object_ptr<Ui::LayerWidget> Memento::createLayer(
@@ -198,7 +198,7 @@ object_ptr<Window::SectionWidget> MoveMemento::createWidget(
 		wrap,
 		this);
 	result->setGeometry(geometry);
-	return std::move(result);
+	return result;
 }
 
 object_ptr<Ui::LayerWidget> MoveMemento::createLayer(

--- a/Telegram/SourceFiles/info/info_wrap_widget.cpp
+++ b/Telegram/SourceFiles/info/info_wrap_widget.cpp
@@ -1043,7 +1043,7 @@ object_ptr<Ui::RpWidget> WrapWidget::createTopBarSurrogate(
 		});
 		result->setGeometry(_topBar->geometry());
 		result->show();
-		return std::move(result);
+		return result;
 	}
 	return nullptr;
 }

--- a/Telegram/SourceFiles/info/media/info_media_buttons.h
+++ b/Telegram/SourceFiles/info/media/info_media_buttons.h
@@ -94,7 +94,7 @@ inline auto AddButton(
 		navigation->showSection(
 			Info::Memento(peer->id, Section(type)));
 	});
-	return std::move(result);
+	return result;
 };
 
 inline auto AddCommonGroupsButton(
@@ -113,7 +113,7 @@ inline auto AddCommonGroupsButton(
 		navigation->showSection(
 			Info::Memento(user->id, Section::Type::CommonGroups));
 	});
-	return std::move(result);
+	return result;
 };
 
 } // namespace Media

--- a/Telegram/SourceFiles/info/media/info_media_widget.cpp
+++ b/Telegram/SourceFiles/info/media/info_media_widget.cpp
@@ -65,7 +65,7 @@ object_ptr<ContentWidget> Memento::createWidget(
 		parent,
 		controller);
 	result->setInternalState(geometry, this);
-	return std::move(result);
+	return result;
 }
 
 Widget::Widget(
@@ -117,7 +117,7 @@ void Widget::setInternalState(
 std::unique_ptr<ContentMemento> Widget::doCreateMemento() {
 	auto result = std::make_unique<Memento>(controller());
 	saveState(result.get());
-	return std::move(result);
+	return result;
 }
 
 void Widget::saveState(not_null<Memento*> memento) {

--- a/Telegram/SourceFiles/info/members/info_members_widget.cpp
+++ b/Telegram/SourceFiles/info/members/info_members_widget.cpp
@@ -38,7 +38,7 @@ object_ptr<ContentWidget> Memento::createWidget(
 		parent,
 		controller);
 	result->setInternalState(geometry, this);
-	return std::move(result);
+	return result;
 }
 
 void Memento::setState(std::unique_ptr<SavedState> state) {
@@ -82,7 +82,7 @@ void Widget::setInternalState(
 std::unique_ptr<ContentMemento> Widget::doCreateMemento() {
 	auto result = std::make_unique<Memento>(controller());
 	saveState(result.get());
-	return std::move(result);
+	return result;
 }
 
 void Widget::saveState(not_null<Memento*> memento) {

--- a/Telegram/SourceFiles/info/profile/info_profile_actions.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_actions.cpp
@@ -344,7 +344,7 @@ object_ptr<Ui::RpWidget> DetailsFiller::setupInfo() {
 		result,
 		st::infoIconInformation,
 		st::infoInformationIconPosition);
-	return std::move(result);
+	return result;
 }
 
 object_ptr<Ui::RpWidget> DetailsFiller::setupMuteToggle() {
@@ -365,7 +365,7 @@ object_ptr<Ui::RpWidget> DetailsFiller::setupMuteToggle() {
 		result,
 		st::infoIconNotifications,
 		st::infoNotificationsIconPosition);
-	return std::move(result);
+	return result;
 }
 
 void DetailsFiller::setupMainButtons() {
@@ -775,7 +775,7 @@ object_ptr<Ui::RpWidget> ActionsFiller::fill() {
 //		result,
 //		st::infoIconNotifications,
 //		st::infoNotificationsIconPosition);
-//	return std::move(result);
+//	return result;
 //}
 
 } // namespace
@@ -870,7 +870,7 @@ object_ptr<Ui::RpWidget> SetupChannelMembers(
 		st::infoChannelMembersIconPosition);
 	members->add(CreateSkipWidget(members));
 
-	return std::move(result);
+	return result;
 }
 // // #feed
 //object_ptr<Ui::RpWidget> SetupFeedDetails(

--- a/Telegram/SourceFiles/info/profile/info_profile_inner_widget.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_inner_widget.cpp
@@ -125,7 +125,7 @@ object_ptr<Ui::RpWidget> InnerWidget::setupContent(
 		}, _members->lifetime());
 		_cover->setOnlineCount(_members->onlineCountValue());
 	}
-	return std::move(result);
+	return result;
 }
 
 object_ptr<Ui::RpWidget> InnerWidget::setupSharedMedia(
@@ -227,7 +227,7 @@ object_ptr<Ui::RpWidget> InnerWidget::setupSharedMedia(
 	)->setAttribute(Qt::WA_TransparentForMouseEvents);
 
 	_sharedMediaWrap = result;
-	return std::move(result);
+	return result;
 }
 
 int InnerWidget::countDesiredHeight() const {

--- a/Telegram/SourceFiles/info/profile/info_profile_widget.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_widget.cpp
@@ -38,7 +38,7 @@ object_ptr<ContentWidget> Memento::createWidget(
 		parent,
 		controller);
 	result->setInternalState(geometry, this);
-	return std::move(result);
+	return result;
 }
 
 void Memento::setMembersState(std::unique_ptr<MembersState> state) {
@@ -102,7 +102,7 @@ void Widget::setInternalState(
 std::unique_ptr<ContentMemento> Widget::doCreateMemento() {
 	auto result = std::make_unique<Memento>(controller());
 	saveState(result.get());
-	return std::move(result);
+	return result;
 }
 
 void Widget::saveState(not_null<Memento*> memento) {

--- a/Telegram/SourceFiles/info/settings/info_settings_widget.cpp
+++ b/Telegram/SourceFiles/info/settings/info_settings_widget.cpp
@@ -32,7 +32,7 @@ object_ptr<ContentWidget> Memento::createWidget(
 		parent,
 		controller);
 	result->setInternalState(geometry, this);
-	return std::move(result);
+	return result;
 }
 
 Memento::~Memento() = default;
@@ -95,7 +95,7 @@ rpl::producer<bool> Widget::desiredShadowVisibility() const {
 std::unique_ptr<ContentMemento> Widget::doCreateMemento() {
 	auto result = std::make_unique<Memento>(self(), _type);
 	saveState(result.get());
-	return std::move(result);
+	return result;
 }
 
 void Widget::saveState(not_null<Memento*> memento) {

--- a/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp
+++ b/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp
@@ -215,7 +215,7 @@ base::variant<FFmpeg::Packet, FFmpeg::AvErrorWrap> File::Context::readPacket() {
 	if (unroll()) {
 		return FFmpeg::AvErrorWrap();
 	} else if (!error) {
-		return std::move(result);
+		return result;
 	} else if (error.code() != AVERROR_EOF) {
 		logFatal(qstr("av_read_frame"), error);
 	}

--- a/Telegram/SourceFiles/passport/passport_panel_controller.cpp
+++ b/Telegram/SourceFiles/passport/passport_panel_controller.cpp
@@ -1192,7 +1192,7 @@ void PanelController::startScopeEdit(
 			_panelHasUnsavedChanges = [=] {
 				return weak ? weak->hasUnsavedChanges() : false;
 			};
-			return std::move(result);
+			return result;
 		} break;
 		case Scope::Type::PersonalDetails:
 		case Scope::Type::AddressDetails: {
@@ -1210,7 +1210,7 @@ void PanelController::startScopeEdit(
 			_panelHasUnsavedChanges = [=] {
 				return weak ? weak->hasUnsavedChanges() : false;
 			};
-			return std::move(result);
+			return result;
 		} break;
 		case Scope::Type::Phone:
 		case Scope::Type::Email: {

--- a/Telegram/SourceFiles/settings/settings_privacy_controllers.cpp
+++ b/Telegram/SourceFiles/settings/settings_privacy_controllers.cpp
@@ -334,7 +334,7 @@ std::unique_ptr<PeerListRow> BlockedBoxController::createRow(
 		return tr::lng_blocked_list_unknown_phone(tr::now);
 	}();
 	row->setCustomStatus(status);
-	return std::move(row);
+	return row;
 }
 
 ApiWrap::Privacy::Key PhoneNumberPrivacyController::key() {
@@ -444,7 +444,7 @@ object_ptr<Ui::RpWidget> PhoneNumberPrivacyController::setupMiddleWidget(
 			QVector<MTPInputPrivacyRule>(1, value));
 	};
 
-	return std::move(widget);
+	return widget;
 }
 
 void PhoneNumberPrivacyController::saveAdditional() {

--- a/Telegram/SourceFiles/settings/settings_privacy_security.cpp
+++ b/Telegram/SourceFiles/settings/settings_privacy_security.cpp
@@ -525,7 +525,7 @@ object_ptr<Ui::BoxContent> EditCloudPasswordBox(not_null<Main::Session*> session
 		session->api().clearUnconfirmedPassword();
 	}, box->lifetime());
 
-	return std::move(result);
+	return result;
 }
 
 void RemoveCloudPassword(not_null<::Main::Session*> session) {
@@ -565,7 +565,7 @@ object_ptr<Ui::BoxContent> CloudPasswordAppOutdatedBox() {
 		tr::lng_menu_update(tr::now),
 		callback);
 	*box = result.data();
-	return std::move(result);
+	return result;
 }
 
 void AddPrivacyButton(

--- a/Telegram/SourceFiles/window/window_outdated_bar.cpp
+++ b/Telegram/SourceFiles/window/window_outdated_bar.cpp
@@ -162,7 +162,7 @@ object_ptr<Ui::RpWidget> CreateOutdatedBar(not_null<QWidget*> parent) {
 		Closed();
 	}, wrap->lifetime());
 
-	return std::move(result);
+	return result;
 }
 
 } // namespace Window


### PR DESCRIPTION
* Do not move result at end of function

This makes GCC 9.1.2 happy with the active -Wredundant-move warning.
Indeed, such moving of local variables or local arguments before
returning is unnecessary and prevents the compiler from copy elision
optimization.