### PR TITLE
Create a new pull request by comparing changes across

### DIFF
--- a/Telegram/SourceFiles/core/utils.cpp
+++ b/Telegram/SourceFiles/core/utils.cpp
@@ -86,7 +86,11 @@ namespace ThirdParty {
 	}
 
 	void finish() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+		EVP_default_properties_enable_fips(nullptr, 0);
+#else
 		FIPS_mode_set(0);
+#endif
 		CONF_modules_unload(1);
 
 		Platform::ThirdParty::finish();


### PR DESCRIPTION
Deprecated function FIPS_mode_set() was removed in OpenSSL 3.0.

Switched to EVP_default_properties_enable_fips() as described in OpenSSL
3.0 migration guide.

Signed-off-by: Vitaly Zaitsev <vitaly@easycoding.org>