### PR TITLE
Create a new pull request by comparing

### DIFF
--- a/lib/xdg/telegramdesktop.desktop
+++ b/lib/xdg/telegramdesktop.desktop
@@ -13,6 +13,7 @@ MimeType=x-scheme-handler/tg;
 Keywords=tg;chat;im;messaging;messenger;sms;tdesktop;
 Actions=Quit;
 X-GNOME-UsesNotifications=true
+X-GNOME-SingleWindow=true
 
 [Desktop Action Quit]
 Exec=telegram-desktop -quit


### PR DESCRIPTION
Telegram is a single-instance app; attempting to open a second instance
fails and simply focuses the existing instance. However the app's
.desktop file does not indicate this to Linux desktop shells like GNOME
and KDE Plasma, causing them to show a "Start new instance/Open new
window" action for the app that will not work when used.

This commit fixes that by setting `X-GNOME-SingleWindow=true` in the
desktop file. This is a GNOME-specific key, but it is honored in KDE
Plasma too.