### PR TITLE
Create a new pull request by comparing changes across two branches

### DIFF
--- a/Telegram/SourceFiles/media/audio/media_audio.cpp
+++ b/Telegram/SourceFiles/media/audio/media_audio.cpp
@@ -345,7 +345,7 @@ void Mixer::Track::createStream(AudioMsgId::Type type) {
 		alSourcei(
 			stream.source,
 			alGetEnumValue("AL_DIRECT_CHANNELS_SOFT"),
-			alcGetEnumValue(nullptr, "AL_REMIX_UNMATCHED_SOFT"));
+			alGetEnumValue("AL_REMIX_UNMATCHED_SOFT"));
 	}
 	alGenBuffers(3, stream.buffers);
 	if (speedEffect) {


### PR DESCRIPTION
This makes no effective change for openal-soft as alGetEnumValue and alcGetEnumValue do lookup in the same table, but it's more semantically right and openal-soft is not the only implementation of the API